### PR TITLE
Add nullable timestamp

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -16,7 +16,7 @@ class CreatePasswordResetsTable extends Migration
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
             $table->string('token')->index();
-            $table->timestamp('created_at');
+            $table->timestamp('created_at')->nullable();
         });
     }
 


### PR DESCRIPTION
Hello bestmomo,
Sans cet ajout du nullable sur le timestamp de la table password_resets, j'ai un plantage lors de la migration en utilisant mysql.
( sqlstate[42000]: syntax error or access violation: 1067 valeur par défaut invalide pour 'created_at' )

@+
Gil - bdfi
