### PR TITLE
Add htaccess in root to point into public folder

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteRule ^(.*)$ public/$1 [L]
+</IfModule>


### PR DESCRIPTION
Bonjour BestMomo

Ne serait-ce pas judicieux de poser cet .htaccess dans la racine de ton dépôt ?

Ainsi, pointer su http://monsite.fr permet d'accéder en fait au dossier public de façon transparente

Sur serveur Apache, ça fonctionne bien, et tout y est (On préserve les URL propres (Sans index.php) les images des 3-4 posts du blob, etc... Et même le B.E. est OK)

Bien-sûr, pour sécuriser, on peut aussi ajouter à chaque autre dossier un .htaccess contenant juste:

deny from all

Et sinon, Bravo, super boulot en complément de http://laravel.sillo.org (y) ! :-)